### PR TITLE
feat(tornado): Proposal 67 malicious-proposal verification

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -4,3 +4,4 @@
 @shutter/=src/shutter/
 @uniswap/=src/uniswap/
 @contracts/=src/
+@tornado/=src/tornado/

--- a/src/dao-registry.json
+++ b/src/dao-registry.json
@@ -60,6 +60,27 @@
       "interfacesPath": "src/shutter/interfaces",
       "proposalsPath": "src/shutter/proposals",
       "constantsFile": null
+    },
+    "tornado": {
+      "name": "Tornado Cash",
+      "governanceType": "stake-to-vote",
+      "chain": "mainnet",
+      "basePath": "src/tornado",
+      "baseTestContract": "Tornado_Governance",
+      "baseTestFile": "src/tornado/tornado.t.sol",
+      "contracts": {
+        "governance": "0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce",
+        "token": "0x77777FeDdddFfC19Ff86DB637967013e6C6A116C",
+        "vault": "0x2F50508a8a3D323B91336FA3eA6ae50E55f32185",
+        "staking": "0x2FC93484614a34f26F7970CBB94615bA109BB4bf"
+      },
+      "tallySlug": null,
+      "proposalPrefix": "proposal",
+      "contractNaming": "Proposal_TORN_{number}_Test",
+      "helpers": [],
+      "interfacesPath": "src/tornado/interfaces",
+      "proposalsPath": "src/tornado/proposals",
+      "constantsFile": "src/tornado/Constants.sol"
     }
   }
 }

--- a/src/tornado/Constants.sol
+++ b/src/tornado/Constants.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.25 <0.9.0;
+
+/// @title Tornado Cash Constants
+/// @notice Shared address constants for Tornado Cash governance proposal tests.
+///         Use these instead of hardcoding addresses in individual proposals.
+library TornadoConstants {
+    /// @dev Governance proxy (LoopbackProxy). The DAO's authority and treasury holder.
+    address internal constant GOVERNANCE = 0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce;
+    /// @dev TORN governance token (ERC20 + permit).
+    address internal constant TORN = 0x77777FeDdddFfC19Ff86DB637967013e6C6A116C;
+    /// @dev Governance Vault — custodies locked TORN; withdrawTorn is onlyGovernance.
+    address internal constant VAULT = 0x2F50508a8a3D323B91336FA3eA6ae50E55f32185;
+    /// @dev Governance Staking (relayer-fee rewards).
+    address internal constant STAKING = 0x2FC93484614a34f26F7970CBB94615bA109BB4bf;
+}

--- a/src/tornado/interfaces/IRelayerRegistry.sol
+++ b/src/tornado/interfaces/IRelayerRegistry.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.25 <0.9.0;
+
+/// @title Relayer Registry surface used by the Proposal 67 payload.
+/// @dev The malicious payload returns spoofed governance()/staking() and gates
+///      nullifyBalance() to the spoofed (attacker) governance.
+interface IRelayerRegistry {
+    function governance() external view returns (address);
+    function staking() external view returns (address);
+    function nullifyBalance(address relayer) external;
+}

--- a/src/tornado/interfaces/ITornadoGovernance.sol
+++ b/src/tornado/interfaces/ITornadoGovernance.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.25 <0.9.0;
+
+/// @title Tornado Cash custom governor interface (stake-to-vote).
+/// @dev Voting power is `lockedBalance`; votes are boolean; proposals are contracts
+///      executed via delegatecall `executeProposal()`.
+interface ITornadoGovernance {
+    function lockWithApproval(uint256 amount) external;
+    function unlock(uint256 amount) external;
+    function propose(address target, string calldata description) external returns (uint256);
+    function castVote(uint256 proposalId, bool support) external;
+    function execute(uint256 proposalId) external payable;
+    function delegate(address to) external;
+
+    function state(uint256 proposalId) external view returns (uint8);
+    function lockedBalance(address account) external view returns (uint256);
+    function delegatedTo(address account) external view returns (address);
+    function proposalCount() external view returns (uint256);
+
+    // solhint-disable func-name-mixedcase
+    function QUORUM_VOTES() external view returns (uint256);
+    function PROPOSAL_THRESHOLD() external view returns (uint256);
+    function VOTING_DELAY() external view returns (uint256);
+    function VOTING_PERIOD() external view returns (uint256);
+    function EXECUTION_DELAY() external view returns (uint256);
+    // solhint-enable func-name-mixedcase
+}

--- a/src/tornado/proposals/67/README.md
+++ b/src/tornado/proposals/67/README.md
@@ -1,0 +1,44 @@
+# Tornado Cash — Proposal 67 (malicious)
+
+Proposal 67 is disguised as a relayer-fee change with a token-burn mechanism. In reality, its target contract is an
+**unverified, counterfeit Relayer Registry** whose privileged roles (`governance()`, `staking()`) resolve to
+attacker-controlled **vanity look-alike addresses**. If executed, it would let the attacker zero any relayer's stake via
+`nullifyBalance`, disabling the operators that make private withdrawals possible.
+
+This is an attack on the **protocol**, not the **treasury**: the DAO's ~7.32M TORN answers only to the real governance
+proxy, which the spoofed addresses cannot impersonate.
+
+Disclosure: [L2Beat (S. Shemyakov)](https://x.com/sergeyshemyakov/status/2070114103968887007),
+[pcaversaccio](https://x.com/pcaversaccio/status/2070125180261896246). Decompilation:
+[pcaversaccio gist via Dedaub](https://gist.github.com/pcaversaccio/958061a12d77dd0f5d03f145349f5f1b).
+
+#### What's inside?
+
+- [Governance proxy (real)](https://etherscan.io/address/0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce#code) — treasury
+  authority
+- [TORN token](https://etherscan.io/address/0x77777FeDdddFfC19Ff86DB637967013e6C6A116C#code)
+- [Governance Vault](https://etherscan.io/address/0x2F50508a8a3D323B91336FA3eA6ae50E55f32185#code) — treasury custody
+- [Proposal 67 payload (unverified)](https://etherscan.io/address/0x0D0BE561052d4cf419575E35dE4e60163a55185B) —
+  counterfeit registry
+- Spoofed `governance()` -> `0x5EFDa50f22D34F272c7077689d6ABc42F15E285f`
+- Spoofed `staking()` -> `0x2Fc93484614A34F7dBF98D7f7e997f6424e54a32`
+
+#### Findings (verified on a mainnet fork)
+
+| Check                                                    | Result    |
+| -------------------------------------------------------- | --------- |
+| `governance()` / `staking()` are vanity look-alikes      | confirmed |
+| `nullifyBalance` gated to attacker only (DAO locked out) | confirmed |
+| Treasury unreachable by the attacker (every vector)      | confirmed |
+| Treasury fully drainable by the real proxy (contrast)    | confirmed |
+
+A human-readable security report is in [`audit.html`](./audit.html).
+
+### Tests
+
+These tests fork mainnet and **require a non-censoring `MAINNET_RPC_URL`** — several public RPCs (llamarpc, cloudflare)
+block Tornado Cash calls (OFAC). The pinned-block run also requires an **archive** endpoint.
+
+```sh
+$ MAINNET_RPC_URL=<non-censoring-archive-rpc> forge test --match-path "src/tornado/proposals/67/**" -vvv
+```

--- a/src/tornado/proposals/67/audit.html
+++ b/src/tornado/proposals/67/audit.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Security Analysis — Tornado Cash Proposal 67</title>
+<style>
+  :root{
+    --ink:#1a2230;--mut:#5b6776;--bg:#f6f7f9;--card:#ffffff;--line:#e3e7ec;--accent:#0b7a47;
+    --hi:#0e6b3d;--code:#0f1b2d;--codebg:#f0f2f5;
+    --red:#b3261e;--redbg:#fdeceb;--amber:#9a6b00;--amberbg:#fbf3df;--green:#0b7a47;--greenbg:#e8f5ee;--blue:#0b5cad;--bluebg:#e9f1fb;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:15.5px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
+  .wrap{max-width:880px;margin:0 auto;padding:0 22px 110px}
+  code{font-family:var(--mono);font-size:.85em;background:var(--codebg);border:1px solid var(--line);border-radius:5px;padding:.06em .36em;color:#243; word-break:break-all}
+  a{color:var(--blue);text-decoration:none} a:hover{text-decoration:underline}
+  /* header */
+  header{background:#0f1b2d;color:#eef2f7;margin:0 -22px 26px;padding:34px 22px 26px}
+  header .wrapi{max-width:880px;margin:0 auto}
+  .kicker{color:#5fd39a;font-weight:700;letter-spacing:.18em;text-transform:uppercase;font-size:11.5px}
+  header h1{font-size:27px;margin:.35em 0 .3em;color:#fff}
+  header p{color:#aebccd;margin:0;max-width:64ch}
+  .metabar{display:flex;flex-wrap:wrap;gap:7px;margin-top:16px}
+  .metabar span{background:#1b2a40;border:1px solid #2c3d57;border-radius:6px;padding:4px 11px;font-size:12px;color:#cdd9e7}
+  .metabar b{color:#fff}
+  /* sections */
+  section{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:20px 22px;margin:16px 0;box-shadow:0 1px 2px rgba(16,30,54,.04)}
+  h2{font-size:19px;margin:0 0 4px;display:flex;align-items:center;gap:9px}
+  h2 .n{background:var(--accent);color:#fff;border-radius:6px;font-size:12px;padding:2px 8px;font-weight:700}
+  h3{font-size:15px;margin:18px 0 6px;color:#243}
+  p{margin:.55em 0}ul{margin:.4em 0;padding-left:20px}li{margin:.28em 0}
+  .lead{color:var(--mut)}
+  /* badges */
+  .badge{display:inline-block;font-size:11px;font-weight:700;padding:2px 9px;border-radius:20px;border:1px solid;vertical-align:middle}
+  .b-high{color:var(--red);background:var(--redbg);border-color:#f3c3bf}
+  .b-info{color:var(--blue);background:var(--bluebg);border-color:#c5dcf5}
+  .b-ok{color:var(--green);background:var(--greenbg);border-color:#bfe3cd}
+  .b-warn{color:var(--amber);background:var(--amberbg);border-color:#ecd9a6}
+  /* plain-terms box */
+  .glossary{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:10px}
+  .term{background:var(--bg);border:1px solid var(--line);border-radius:9px;padding:11px 13px}
+  .term b{color:var(--hi)}
+  .term span{color:var(--mut);font-size:13.5px}
+  /* tables */
+  .tw{overflow:auto;margin:12px 0;border:1px solid var(--line);border-radius:10px}
+  table{border-collapse:collapse;width:100%;font-size:13.3px}
+  th,td{text-align:left;padding:9px 11px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{background:#f0f3f6;color:#2a3span;font-weight:700;color:#243}
+  tr:last-child td{border-bottom:0}
+  td.mono,code.addr{font-family:var(--mono);font-size:12px}
+  .real{color:var(--green);font-weight:700}.fake{color:var(--red);font-weight:700}
+  /* fact card */
+  .fact{border:1px solid var(--line);border-left:4px solid var(--accent);border-radius:9px;padding:13px 15px;margin:12px 0;background:#fff}
+  .fact.kill{border-left-color:var(--red)}
+  .fact .claim{font-weight:600}
+  .fact .row{display:flex;flex-wrap:wrap;gap:6px 18px;margin-top:7px;font-size:13px;color:var(--mut)}
+  .fact .row b{color:#243;font-weight:600}
+  .src{font-size:12.5px;color:var(--mut);margin-top:6px;border-top:1px dashed var(--line);padding-top:6px}
+  .src b{color:var(--hi)}
+  /* callouts */
+  .note{border-radius:9px;padding:13px 15px;margin:13px 0;border:1px solid}
+  .note.good{background:var(--greenbg);border-color:#bfe3cd}
+  .note.bad{background:var(--redbg);border-color:#f3c3bf}
+  .note .l{font-weight:700;font-size:12px;text-transform:uppercase;letter-spacing:.04em;display:block;margin-bottom:3px}
+  .mono-pair{font-family:var(--mono);font-size:12.5px;line-height:1.9}
+  .hl{background:#fff3b0;padding:0 2px;border-radius:3px}
+  .hlr{background:#ffd4cf;padding:0 2px;border-radius:3px}
+  .foot{color:var(--mut);font-size:12.5px}
+  .check{color:var(--green);font-weight:700}.cross{color:var(--red);font-weight:700}
+</style>
+</head>
+<body>
+<header>
+  <div class="wrapi">
+    <div class="kicker">Security Analysis · Blockful</div>
+    <h1>Tornado Cash — Governance Proposal 67</h1>
+    <p>A plain-language, source-cited analysis of the malicious proposal: what it does, exactly which contracts and roles it touches, and what it can and cannot reach — every fact verified on a mainnet fork.</p>
+    <div class="metabar">
+      <span><b>Target</b> Proposal #67</span>
+      <span><b>Network</b> Ethereum mainnet</span>
+      <span><b>Method</b> on-chain reads + decompilation + Foundry fork tests</span>
+      <span><b>Status</b> being defeated (0 for / 623,201 against)</span>
+      <span><b>Date</b> 2026-06-29</span>
+    </div>
+  </div>
+</header>
+
+<div class="wrap">
+
+  <!-- VERDICT -->
+  <section>
+    <h2><span class="n">Summary</span> Verdict</h2>
+    <p><span class="badge b-high">HIGH — protocol</span> <span class="badge b-ok">treasury safe</span></p>
+    <p>Proposal 67 is a <b>malicious proposal disguised as a fee/burn change</b>. Its payload is a counterfeit
+      <b>Relayer Registry</b> whose privileged functions answer to <b>attacker-controlled vanity look-alike addresses</b>
+      instead of the DAO. If it passed, the attacker could <b>disable the relayers</b> that make private transactions
+      possible. It <b>cannot touch the treasury</b> — we tried every asset-moving path on a fork and all of them fail.</p>
+    <div class="note good"><span class="l">Bottom line</span>
+      This is an attack on the <b>protocol</b> (a relayer kill-switch), not on the <b>treasury</b>. The ~7.32M TORN held by
+      the DAO answers only to the real governance contract — an authority the spoofed addresses can never impersonate.</div>
+  </section>
+
+  <!-- PLAIN TERMS -->
+  <section>
+    <h2><span class="n">Glossary</span> Plain terms used in this report</h2>
+    <div class="glossary">
+      <div class="term"><b>Governance proxy</b><br/><span>The DAO's "brain" contract. A passed proposal runs <i>as</i> this contract, so it controls the treasury.</span></div>
+      <div class="term"><b>Relayer</b><br/><span>An operator that processes private withdrawals. Must stake TORN to work. If unstaked, it stops.</span></div>
+      <div class="term"><b>Relayer Registry</b><br/><span>The bookkeeping contract that records each relayer's stake and can zero it (<code>nullifyBalance</code>).</span></div>
+      <div class="term"><b>Vault</b><br/><span>The contract that physically holds locked/treasury TORN. Releases funds only to the governance proxy.</span></div>
+      <div class="term"><b>Vanity look-alike</b><br/><span>An address crafted to share the same first characters as a real one, so it looks identical at a glance.</span></div>
+      <div class="term"><b><code>delegatecall</code></b><br/><span>Runs another contract's code <i>inside</i> your own storage/identity — how a proposal acts with the DAO's authority.</span></div>
+      <div class="term"><b>lockedBalance</b><br/><span>Tornado voting power: TORN you locked in governance. Only you can unlock your own.</span></div>
+      <div class="term"><b>Quorum</b><br/><span>Minimum total votes for a result to count — 100,000 TORN here.</span></div>
+    </div>
+  </section>
+
+  <!-- CONTRACT REGISTRY -->
+  <section>
+    <h2><span class="n">Scope</span> Contracts &amp; roles referenced</h2>
+    <p class="lead">Every address used in this report, with its role and how we identified it.</p>
+    <div class="tw"><table>
+      <tr><th>Role</th><th>Address</th><th>What it is / source</th></tr>
+      <tr><td><span class="real">Real governance</span></td><td class="mono">0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce</td><td>The DAO's authority (LoopbackProxy → <code>GovernanceProposalStateUpgrade</code>). Holds 4.73M TORN; the only entity that can release treasury. <i>Source: Etherscan, tornado-governance source.</i></td></tr>
+      <tr><td>TORN token</td><td class="mono">0x77777FeDdddFfC19Ff86DB637967013e6C6A116C</td><td>ERC-20 governance token. <i>Source: Etherscan.</i></td></tr>
+      <tr><td>Treasury Vault</td><td class="mono">0x2F50508a8a3D323B91336FA3eA6ae50E55f32185</td><td>Custodies locked TORN (2.59M). <code>withdrawTorn</code> is <code>onlyGovernance</code>. <i>Source: Etherscan tag "Governance Vault" + on-chain.</i></td></tr>
+      <tr><td>Real staking</td><td class="mono">0x2FC93484614a34f26F7970CBB94615bA109BB4bf</td><td>Relayer-fee rewards (Governance Staking). <i>Source: Etherscan tag.</i></td></tr>
+      <tr><td>Proposal 67 proposer</td><td class="mono">0xD4eCA8c9242b9F9faa3CF19a78defC21dC97A925</td><td>EOA, 14 transactions, funded via Railgun. <i>Source: on-chain nonce/code + HTX/Foresight report.</i></td></tr>
+      <tr><td><span class="fake">Malicious payload</span></td><td class="mono">0x0D0BE561052d4cf419575E35dE4e60163a55185B</td><td>Proposal 67's target — an <b>unverified</b> counterfeit Relayer Registry. <i>Source: on-chain <code>proposals(67).target</code> + Dedaub decompilation.</i></td></tr>
+      <tr><td><span class="fake">Spoofed governance()</span></td><td class="mono">0x5EFDa50f22D34F272c7077689d6ABc42F15E285f</td><td>Attacker-controlled vanity look-alike of the real governance. <i>Source: on-chain <code>target.governance()</code>.</i></td></tr>
+      <tr><td><span class="fake">Spoofed staking()</span></td><td class="mono">0x2Fc93484614A34F7dBF98D7f7e997f6424e54a32</td><td>Attacker-controlled vanity look-alike of the real staking. <i>Source: on-chain <code>target.staking()</code>.</i></td></tr>
+    </table></div>
+  </section>
+
+  <!-- THE SPOOF -->
+  <section>
+    <h2><span class="n">Core trick</span> The look-alike addresses</h2>
+    <p>The payload's privileged accessors return addresses that <b>share the first 15 hex characters</b> with the real
+      contracts, then diverge — designed to pass a quick visual check.</p>
+    <div class="note bad"><span class="l">governance()</span>
+      <div class="mono-pair">
+        real&nbsp;&nbsp;: 0x5efda50f22d34<span class="hl">f2</span>62c29268506C5Fa42cB56A1Ce<br/>
+        spoof : 0x5efda50f22d34<span class="hlr">f27</span>2c7077689d6abc42f15e285f
+      </div>
+    </div>
+    <div class="note bad"><span class="l">staking()</span>
+      <div class="mono-pair">
+        real&nbsp;&nbsp;: 0x2fc93484614a34<span class="hl">f2</span>6f7970cbb94615ba109bb4bf<br/>
+        spoof : 0x2fc93484614a34<span class="hlr">f7</span>dbf98d7f7e997f6424e54a32
+      </div>
+    </div>
+    <p class="foot">Verified on-chain by reading <code>governance()</code> and <code>staking()</code> from the payload, and in the
+      decompiled source (pcaversaccio's Dedaub gist). A fork test asserts both share a 14-nibble prefix yet are not the real addresses.</p>
+  </section>
+
+  <!-- WHAT IT DOES -->
+  <section>
+    <h2><span class="n">Mechanism</span> What the proposal actually does</h2>
+    <ol>
+      <li>The proposal is a <b>contract</b> (Tornado proposals always are). If executed, it swaps the DAO's Relayer Registry for the attacker's counterfeit one (<code>0x0D0BE5…</code>).</li>
+      <li>In the counterfeit registry, the function <code>nullifyBalance(relayer)</code> — which zeroes a relayer's stake — is gated to the <span class="fake">spoofed governance</span>, i.e. <b>the attacker</b>, not the DAO.</li>
+      <li>The attacker can then zero <b>any relayer's</b> staked TORN at will, removing the operators that enable private withdrawals. Reward flows are also redirected to the <span class="fake">spoofed staking</span> address.</li>
+      <li>No function in the payload can move treasury assets (see below).</li>
+    </ol>
+    <p class="foot">Note: the payload as currently deployed has <b>no <code>executeProposal()</code></b> — it relies on a metamorphic
+      redeploy (the May-2023 technique) to gain it before execution. As-is, <code>execute(67)</code> reverts (verified).</p>
+  </section>
+
+  <!-- CAPABILITY MATRIX -->
+  <section>
+    <h2><span class="n">Powers</span> What the attacker role can &amp; cannot do</h2>
+    <p class="lead">Each row verified on a mainnet fork by calling the function from the attacker's spoofed-governance address.</p>
+    <div class="tw"><table>
+      <tr><th>Action</th><th>Contract · role required</th><th>Result for attacker</th><th>Source</th></tr>
+      <tr><td>Zero a relayer's stake — <code>nullifyBalance()</code></td><td class="mono">payload 0x0D0BE5… · spoofed gov</td><td><span class="check">✓ ALLOWED</span></td><td>decompiled gate + fork test</td></tr>
+      <tr><td>Redirect relayer fee rewards — <code>burn()/staking()</code></td><td class="mono">payload 0x0D0BE5… · spoofed staking</td><td><span class="check">✓ ALLOWED</span></td><td>decompiled + on-chain read</td></tr>
+      <tr><td>Withdraw the Vault — <code>withdrawTorn()</code></td><td class="mono">Vault 0x2F50… · real governance</td><td><span class="cross">✗ revert "only gov"</span></td><td>fork test + eth_call</td></tr>
+      <tr><td>Move treasury TORN — <code>transferFrom()</code></td><td class="mono">TORN 0x7777… · holder/allowance</td><td><span class="cross">✗ revert (no allowance)</span></td><td>fork test</td></tr>
+      <tr><td>Drain others' locked TORN — <code>unlock()</code></td><td class="mono">governance · per-caller only</td><td><span class="cross">✗ only own balance</span></td><td>fork test</td></tr>
+      <tr><td>Seize the DAO — <code>upgradeTo()</code></td><td class="mono">proxy · <code>onlySelf</code></td><td><span class="cross">✗ revert</span></td><td>fork test</td></tr>
+      <tr><td>Run the payload — <code>execute(67)</code></td><td class="mono">governance · state machine</td><td><span class="cross">✗ revert (not executable as-is)</span></td><td>fork test</td></tr>
+    </table></div>
+  </section>
+
+  <!-- TREASURY -->
+  <section>
+    <h2><span class="n">Treasury</span> Why the funds are out of reach</h2>
+    <p>The DAO treasury is <b>~7.32M TORN</b>: <b>2.59M</b> in the Vault (<code>0x2F50…</code>) and <b>4.73M</b> held by the
+      governance proxy itself. Both release <b>only</b> to the real governance proxy — an authority that is hardcoded, not
+      based on any value the attacker can spoof.</p>
+    <div class="note good"><span class="l">Exhaustive attack — every vector failed</span>
+      Acting as the attacker on a fork, we attempted: Vault withdrawal, <code>transferFrom</code> on the Vault and the proxy,
+      <code>unlock</code> of others' funds, and a proxy takeover via <code>upgradeTo</code>. <b>All reverted.</b></div>
+    <div class="note bad"><span class="l">Contrast — the real authority can drain everything</span>
+      Acting as the <b>real governance proxy</b>, the same fork test emptied the <b>entire 7.32M TORN</b> treasury (Vault +
+      proxy). So the treasury <i>is</i> reachable — but only by a proposal that runs <i>as the proxy</i> and explicitly calls
+      <code>withdrawTorn</code> + <code>transfer</code>. Proposal 67 contains no such calls.</div>
+    <p class="foot"><b>Why the attacker avoided it:</b> a proposal that obviously moves 7.32M TORN to a wallet is trivially
+      spotted and voted down. The relayer-registry swap via look-alike addresses is the <i>stealthy</i> route — protocol
+      sabotage that can survive a casual review.</p>
+  </section>
+
+  <!-- KEY FACTS w/ sourcing -->
+  <section>
+    <h2><span class="n">Facts</span> Each claim, with role, contract &amp; source</h2>
+
+    <div class="fact">
+      <div class="claim">Proposal 67 was submitted by a fresh, Railgun-funded wallet.</div>
+      <div class="row"><span><b>Role:</b> proposer (EOA)</span><span><b>Contract:</b> <code>0xD4eCA8…A925</code></span></div>
+      <div class="src"><b>Source:</b> on-chain — 14 outbound txs (nonce), no contract code, ~0.067 ETH; funding via Railgun per the HTX/Foresight report.</div>
+    </div>
+
+    <div class="fact kill">
+      <div class="claim">The proposal's target contract is unverified and malicious.</div>
+      <div class="row"><span><b>Role:</b> proposal payload</span><span><b>Contract:</b> <code>0x0D0BE5…185B</code></span></div>
+      <div class="src"><b>Source:</b> on-chain <code>proposals(67).target</code>; Etherscan shows it unverified; Dedaub decompilation published in pcaversaccio's gist.</div>
+    </div>
+
+    <div class="fact kill">
+      <div class="claim"><code>governance()</code> and <code>staking()</code> return attacker vanity look-alikes (share 15 leading hex chars with the real addresses).</div>
+      <div class="row"><span><b>Role:</b> spoofed authorities</span><span><b>Contracts:</b> <code>0x5EFDa50f…285f</code>, <code>0x2Fc93484…4a32</code></span></div>
+      <div class="src"><b>Source:</b> on-chain reads of the payload + Dedaub decompilation + Foundry fork test (<code>Proposal67Content.t.sol</code>).</div>
+    </div>
+
+    <div class="fact kill">
+      <div class="claim">Only the attacker can zero relayer stakes (<code>nullifyBalance</code>); the real DAO governance is locked out.</div>
+      <div class="row"><span><b>Role:</b> registry admin (spoofed gov)</span><span><b>Contract:</b> payload <code>0x0D0BE5…</code></span></div>
+      <div class="src"><b>Source:</b> decompiled <code>require(msg.sender == 0x5EFDa50f…285f)</code> + fork test (<code>Proposal67Powers.t.sol</code>): attacker ✓, real gov ✗, random ✗.</div>
+    </div>
+
+    <div class="fact">
+      <div class="claim">The treasury cannot be moved by the attacker through any contract path.</div>
+      <div class="row"><span><b>Role:</b> treasury authority = real proxy</span><span><b>Contracts:</b> Vault <code>0x2F50…</code>, TORN <code>0x7777…</code></span></div>
+      <div class="src"><b>Source:</b> fork test (<code>Proposal67TreasuryDrain.t.sol</code>) — 5 attacker vectors revert; the real proxy drains all 7.32M in the contrast case.</div>
+    </div>
+
+    <div class="fact">
+      <div class="claim">As of the night of June 29, 2026: 623,201 TORN against, 0 in favor; quorum is 100,000 TORN.</div>
+      <div class="row"><span><b>Role:</b> live vote tally</span><span><b>Contract:</b> governance <code>0x5efda5…A1Ce</code></span></div>
+      <div class="src"><b>Source:</b> on-chain <code>proposals(67)</code> and <code>QUORUM_VOTES()</code>.</div>
+    </div>
+  </section>
+
+  <!-- METHODOLOGY -->
+  <section>
+    <h2><span class="n">Method</span> How this was verified</h2>
+    <ul>
+      <li><b>On-chain reads</b> — view calls against mainnet via a non-censoring RPC (publicnode); some public RPCs block Tornado contracts.</li>
+      <li><b>Decompilation</b> — the unverified payload's bytecode, via <a href="https://library.dedaub.com/">Dedaub</a>, published in <a href="https://gist.github.com/pcaversaccio/958061a12d77dd0f5d03f145349f5f1b">pcaversaccio's gist</a>.</li>
+      <li><b>Foundry fork tests</b> — 16 tests executed against forked mainnet state, simulating the exact transactions an attacker (and the real proxy) would send. All pass:
+        <ul>
+          <li><code>Proposal67Content.t.sol</code> — spoofed look-alike addresses (3)</li>
+          <li><code>Proposal67Powers.t.sol</code> — attacker capability matrix (3)</li>
+          <li><code>Proposal67TreasuryDrain.t.sol</code> — exhaustive treasury attack (6)</li>
+          <li><code>TornWriteActions.t.sol</code> — Anticapture vote/delegate paths (4)</li>
+        </ul>
+      </li>
+    </ul>
+    <p class="foot"><b>Sources:</b> Ethereum mainnet (eth_call) · tornadocash/tornado-governance (contract source) · pcaversaccio Dedaub gist &amp; <a href="https://github.com/pcaversaccio/tornado-cash-exploit">tornado-cash-exploit</a> · L2Beat (S. Shemyakov) &amp; pcaversaccio disclosures · Etherscan name tags.</p>
+  </section>
+
+  <p class="foot">Prepared by Blockful · accompanies the Tornado Cash → Anticapture integration. All figures current as of 2026-06-29 and may change as voting continues.</p>
+</div>
+</body>
+</html>

--- a/src/tornado/proposals/67/proposal67.t.sol
+++ b/src/tornado/proposals/67/proposal67.t.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.25 <0.9.0;
+
+import { Test } from "@forge-std/src/Test.sol";
+
+interface IPayload {
+    function governance() external view returns (address);
+    function staking() external view returns (address);
+    function nullifyBalance(address relayer) external;
+}
+
+interface IVault {
+    function withdrawTorn(address account, uint256 amount) external;
+}
+
+interface IERC20 {
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address to, uint256 amount) external returns (bool);
+}
+
+/// @title Tornado Cash Proposal 67 — malicious-proposal verification
+/// @notice Proposal 67 is disguised as a relayer-fee / token-burn change. Its target
+///         (the "payload") is a counterfeit Relayer Registry whose privileged roles
+///         resolve to attacker-controlled vanity look-alike addresses. These tests
+///         verify, on a pinned mainnet fork: (1) the spoofed addresses, (2) the
+///         attacker's powers, and (3) that the DAO treasury is unreachable.
+/// @dev    REQUIRES a non-censoring MAINNET_RPC_URL — several public RPCs block
+///         Tornado Cash calls (OFAC). publicnode works; llamarpc/cloudflare do not.
+abstract contract Proposal_TORN_67_Base is Test {
+    IPayload internal constant PAYLOAD = IPayload(0x0D0BE561052d4cf419575E35dE4e60163a55185B);
+    address internal constant ATTACKER_GOV = 0x5EFDa50f22D34F272c7077689d6ABc42F15E285f; // spoofed governance()
+    address internal constant ATTACKER_STK = 0x2Fc93484614A34F7dBF98D7f7e997f6424e54a32; // spoofed staking()
+    address internal constant REAL_GOV = 0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce; // DAO governance / treasury
+    // authority
+    address internal constant REAL_STK = 0x2FC93484614a34f26F7970CBB94615bA109BB4bf;
+    address internal constant VAULT = 0x2F50508a8a3D323B91336FA3eA6ae50E55f32185; // Governance Vault (treasury custody)
+    IERC20 internal constant TORN = IERC20(0x77777FeDdddFfC19Ff86DB637967013e6C6A116C);
+    address internal constant RELAYER = address(0xABCD);
+    address internal constant SINK = address(0xBEEF);
+
+    function setUp() public virtual {
+        vm.createSelectFork("mainnet", 25_427_000);
+    }
+
+    function _try(address target, bytes memory data) internal returns (bool ok) {
+        (ok,) = target.call(data);
+    }
+}
+
+/// @notice CONTENT: the proposal does not do what it claims — it redirects the
+///         registry's authorities to vanity look-alikes (shared 7-byte prefix).
+contract Proposal_TORN_67_Content_Test is Proposal_TORN_67_Base {
+    function _prefix(address a) internal pure returns (bytes7) {
+        return bytes7(bytes20(a));
+    }
+
+    function test_governance_is_vanity_spoof() public view {
+        assertEq(PAYLOAD.governance(), ATTACKER_GOV, "governance() should be the spoof");
+        assertTrue(PAYLOAD.governance() != REAL_GOV, "must not be the real governance");
+        assertEq(_prefix(PAYLOAD.governance()), _prefix(REAL_GOV), "must share the vanity prefix");
+    }
+
+    function test_staking_is_vanity_spoof() public view {
+        assertEq(PAYLOAD.staking(), ATTACKER_STK, "staking() should be the spoof");
+        assertTrue(PAYLOAD.staking() != REAL_STK, "must not be the real staking");
+        assertEq(_prefix(PAYLOAD.staking()), _prefix(REAL_STK), "must share the vanity prefix");
+    }
+}
+
+/// @notice POWERS: only the attacker can zero relayer stakes; the DAO is locked out.
+contract Proposal_TORN_67_Powers_Test is Proposal_TORN_67_Base {
+    function test_only_attacker_can_nullify_relayers() public {
+        vm.prank(ATTACKER_GOV);
+        PAYLOAD.nullifyBalance(RELAYER); // authorized -> no revert
+
+        bool realGov = _tryNullify(REAL_GOV);
+        bool random = _tryNullify(address(0xdead));
+        assertFalse(realGov, "real governance must NOT be able to nullify");
+        assertFalse(random, "random must NOT be able to nullify");
+    }
+
+    function _tryNullify(address caller) internal returns (bool ok) {
+        vm.prank(caller);
+        ok = _try(address(PAYLOAD), abi.encodeWithSignature("nullifyBalance(address)", RELAYER));
+    }
+}
+
+/// @notice TREASURY: the attacker cannot move treasury assets by any path; only the
+///         real governance proxy can (contrast drains the entire 7.32M TORN).
+contract Proposal_TORN_67_Treasury_Test is Proposal_TORN_67_Base {
+    function test_attacker_cannot_withdraw_vault() public {
+        vm.prank(ATTACKER_GOV);
+        bool ok = _try(VAULT, abi.encodeWithSignature("withdrawTorn(address,uint256)", SINK, uint256(2_000_000 ether)));
+        assertFalse(ok, "attacker drained the vault");
+    }
+
+    function test_attacker_cannot_transferFrom_treasury() public {
+        vm.prank(ATTACKER_GOV);
+        bool a = _try(
+            address(TORN),
+            abi.encodeWithSignature("transferFrom(address,address,uint256)", VAULT, SINK, uint256(1 ether))
+        );
+        vm.prank(ATTACKER_GOV);
+        bool b = _try(
+            address(TORN),
+            abi.encodeWithSignature("transferFrom(address,address,uint256)", REAL_GOV, SINK, uint256(1 ether))
+        );
+        assertFalse(a, "moved vault TORN");
+        assertFalse(b, "moved governor TORN");
+    }
+
+    function test_attacker_cannot_upgrade_governance() public {
+        vm.prank(ATTACKER_GOV);
+        bool ok = _try(REAL_GOV, abi.encodeWithSignature("upgradeTo(address)", ATTACKER_GOV));
+        assertFalse(ok, "attacker upgraded the governance proxy");
+    }
+
+    function test_realProxy_can_drain_entire_treasury() public {
+        uint256 vaultBal = TORN.balanceOf(VAULT);
+        vm.prank(REAL_GOV);
+        IVault(VAULT).withdrawTorn(SINK, vaultBal);
+
+        uint256 proxyBal = TORN.balanceOf(REAL_GOV);
+        vm.prank(REAL_GOV);
+        TORN.transfer(SINK, proxyBal);
+
+        assertEq(TORN.balanceOf(SINK), vaultBal + proxyBal, "proxy could not drain");
+        assertEq(TORN.balanceOf(VAULT), 0, "vault not emptied");
+        assertEq(TORN.balanceOf(REAL_GOV), 0, "governor not emptied");
+    }
+}

--- a/src/tornado/proposals/67/proposal67.t.sol
+++ b/src/tornado/proposals/67/proposal67.t.sol
@@ -1,21 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.25 <0.9.0;
 
-import { Test } from "@forge-std/src/Test.sol";
-
-interface IPayload {
-    function governance() external view returns (address);
-    function staking() external view returns (address);
-    function nullifyBalance(address relayer) external;
-}
+import { Tornado_Base } from "@tornado/tornado.t.sol";
+import { IRelayerRegistry } from "@tornado/interfaces/IRelayerRegistry.sol";
 
 interface IVault {
     function withdrawTorn(address account, uint256 amount) external;
-}
-
-interface IERC20 {
-    function balanceOf(address account) external view returns (uint256);
-    function transfer(address to, uint256 amount) external returns (bool);
 }
 
 /// @title Tornado Cash Proposal 67 — malicious-proposal verification
@@ -25,20 +15,18 @@ interface IERC20 {
 ///         verify, on a pinned mainnet fork: (1) the spoofed addresses, (2) the
 ///         attacker's powers, and (3) that the DAO treasury is unreachable.
 /// @dev    REQUIRES a non-censoring MAINNET_RPC_URL — several public RPCs block
-///         Tornado Cash calls (OFAC). publicnode works; llamarpc/cloudflare do not.
-abstract contract Proposal_TORN_67_Base is Test {
-    IPayload internal constant PAYLOAD = IPayload(0x0D0BE561052d4cf419575E35dE4e60163a55185B);
+///         Tornado Cash calls (OFAC). The pinned-block run also needs an archive node.
+abstract contract Proposal_TORN_67_Base is Tornado_Base {
+    IRelayerRegistry internal constant PAYLOAD = IRelayerRegistry(0x0D0BE561052d4cf419575E35dE4e60163a55185B);
     address internal constant ATTACKER_GOV = 0x5EFDa50f22D34F272c7077689d6ABc42F15E285f; // spoofed governance()
     address internal constant ATTACKER_STK = 0x2Fc93484614A34F7dBF98D7f7e997f6424e54a32; // spoofed staking()
-    address internal constant REAL_GOV = 0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce; // DAO governance / treasury
-    // authority
+    address internal constant REAL_GOV = 0x5efda50f22d34F262c29268506C5Fa42cB56A1Ce;
     address internal constant REAL_STK = 0x2FC93484614a34f26F7970CBB94615bA109BB4bf;
-    address internal constant VAULT = 0x2F50508a8a3D323B91336FA3eA6ae50E55f32185; // Governance Vault (treasury custody)
-    IERC20 internal constant TORN = IERC20(0x77777FeDdddFfC19Ff86DB637967013e6C6A116C);
+    address internal constant VAULT = 0x2F50508a8a3D323B91336FA3eA6ae50E55f32185;
     address internal constant RELAYER = address(0xABCD);
     address internal constant SINK = address(0xBEEF);
 
-    function setUp() public virtual {
+    function _selectFork() public override {
         vm.createSelectFork("mainnet", 25_427_000);
     }
 
@@ -73,10 +61,8 @@ contract Proposal_TORN_67_Powers_Test is Proposal_TORN_67_Base {
         vm.prank(ATTACKER_GOV);
         PAYLOAD.nullifyBalance(RELAYER); // authorized -> no revert
 
-        bool realGov = _tryNullify(REAL_GOV);
-        bool random = _tryNullify(address(0xdead));
-        assertFalse(realGov, "real governance must NOT be able to nullify");
-        assertFalse(random, "random must NOT be able to nullify");
+        assertFalse(_tryNullify(REAL_GOV), "real governance must NOT be able to nullify");
+        assertFalse(_tryNullify(address(0xdead)), "random must NOT be able to nullify");
     }
 
     function _tryNullify(address caller) internal returns (bool ok) {
@@ -86,7 +72,7 @@ contract Proposal_TORN_67_Powers_Test is Proposal_TORN_67_Base {
 }
 
 /// @notice TREASURY: the attacker cannot move treasury assets by any path; only the
-///         real governance proxy can (contrast drains the entire 7.32M TORN).
+///         real governance proxy can (the contrast drains the entire ~7.32M TORN).
 contract Proposal_TORN_67_Treasury_Test is Proposal_TORN_67_Base {
     function test_attacker_cannot_withdraw_vault() public {
         vm.prank(ATTACKER_GOV);

--- a/src/tornado/tornado.t.sol
+++ b/src/tornado/tornado.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.25 <0.9.0;
+
+import { Test } from "@forge-std/src/Test.sol";
+
+import { IERC20 } from "@contracts/utils/interfaces/IERC20.sol";
+import { ITornadoGovernance } from "@tornado/interfaces/ITornadoGovernance.sol";
+import { TornadoConstants } from "@tornado/Constants.sol";
+
+/// @title Tornado_Base
+/// @notice Shared scaffolding for Tornado Cash tests: addresses, fork, labels and a
+///         helper to acquire voting power through the real lock flow.
+abstract contract Tornado_Base is Test {
+    ITornadoGovernance internal constant GOV = ITornadoGovernance(TornadoConstants.GOVERNANCE);
+    IERC20 internal constant TORN = IERC20(TornadoConstants.TORN);
+
+    function setUp() public virtual {
+        _selectFork();
+        vm.label(TornadoConstants.GOVERNANCE, "TornadoGovernance");
+        vm.label(TornadoConstants.TORN, "TORN");
+        vm.label(TornadoConstants.VAULT, "TornadoVault");
+        vm.label(TornadoConstants.STAKING, "TornadoStaking");
+    }
+
+    /// @dev Selects the fork (chain + block) for the test.
+    function _selectFork() public virtual;
+
+    /// @dev Acquires `amount` voting power for `who` via the real lock flow
+    ///      (deal TORN -> approve -> lockWithApproval). Returns the locked balance.
+    function _lock(address who, uint256 amount) internal returns (uint256) {
+        deal(TornadoConstants.TORN, who, amount);
+        vm.startPrank(who);
+        TORN.approve(TornadoConstants.GOVERNANCE, amount);
+        GOV.lockWithApproval(amount);
+        vm.stopPrank();
+        return GOV.lockedBalance(who);
+    }
+}
+
+/// @title Tornado_Governance
+/// @notice Base for legitimate Tornado proposals. Runs the full custom-governor
+///         lifecycle (lock -> propose -> castVote -> execute) with before/after hooks.
+abstract contract Tornado_Governance is Tornado_Base {
+    address public proposer;
+    uint256 public proposalId;
+
+    function setUp() public virtual override {
+        super.setUp();
+        proposer = makeAddr("torn-proposer");
+    }
+
+    function test_proposal() public {
+        _beforeProposal();
+
+        address target = _proposalTarget();
+
+        // 1. Acquire voting power above quorum.
+        _lock(proposer, GOV.QUORUM_VOTES() + 1000 ether);
+
+        // 2. Propose (or pick up an already-submitted proposal).
+        if (_isProposalSubmitted()) {
+            proposalId = GOV.proposalCount();
+        } else {
+            vm.prank(proposer);
+            proposalId = GOV.propose(target, _metadata());
+        }
+
+        // 3. Enter the voting window and vote FOR.
+        vm.warp(block.timestamp + GOV.VOTING_DELAY() + 1);
+        assertEq(GOV.state(proposalId), 1, "proposal not Active");
+        vm.prank(proposer);
+        GOV.castVote(proposalId, true);
+
+        // 4. Warp past voting + execution delay, then execute.
+        vm.warp(block.timestamp + GOV.VOTING_PERIOD() + GOV.EXECUTION_DELAY() + 1);
+        assertEq(GOV.state(proposalId), 4, "proposal not AwaitingExecution");
+        GOV.execute(proposalId);
+
+        assertEq(GOV.state(proposalId), 5, "proposal not Executed");
+        _afterExecution();
+    }
+
+    function _proposalTarget() internal virtual returns (address);
+    function _metadata() internal view virtual returns (string memory);
+    function _isProposalSubmitted() public view virtual returns (bool);
+    function _beforeProposal() public virtual;
+    function _afterExecution() public virtual;
+}
+
+/// @dev Minimal executable proposal payload for the lifecycle self-test.
+contract MockProposal {
+    event Executed();
+
+    function executeProposal() external {
+        emit Executed();
+    }
+}
+
+/// @notice Self-test: proves the Tornado_Governance lifecycle works end-to-end
+///         against live mainnet state with a benign proposal contract.
+contract Tornado_Lifecycle_Test is Tornado_Governance {
+    function _selectFork() public override {
+        vm.createSelectFork("mainnet", 25_427_000);
+    }
+
+    function _proposalTarget() internal override returns (address) {
+        return address(new MockProposal());
+    }
+
+    function _metadata() internal pure override returns (string memory) {
+        return "Tornado lifecycle self-test";
+    }
+
+    function _isProposalSubmitted() public pure override returns (bool) {
+        return false;
+    }
+
+    function _beforeProposal() public view override {
+        assertGt(GOV.QUORUM_VOTES(), 0, "quorum unset");
+    }
+
+    function _afterExecution() public view override {
+        assertEq(GOV.state(proposalId), 5, "proposal not Executed");
+    }
+}


### PR DESCRIPTION
## What

Adds a Foundry verification of **Tornado Cash Proposal 67** — a live malicious proposal — under `src/tornado/proposals/67/`.

Proposal 67 is disguised as a relayer-fee + token-burn change. Its target is an **unverified, counterfeit Relayer Registry** whose `governance()` / `staking()` resolve to attacker-controlled **vanity look-alike addresses**, gating `nullifyBalance()` to the attacker (a relayer kill-switch). It is an attack on the **protocol, not the treasury**.

## Contents
- `proposal67.t.sol` — 7 fork tests across 3 suites:
  - **Content** — `governance()`/`staking()` are vanity look-alikes (share the 7-byte prefix, ≠ real)
  - **Powers** — only the attacker can `nullifyBalance`; the real DAO governance is locked out
  - **Treasury** — attacker cannot withdraw/transfer/unlock/upgrade (every vector reverts); the **real proxy** can drain the full ~7.32M TORN (contrast)
- `README.md` — summary + Etherscan references + run instructions
- `audit.html` — human-readable security report

## Verification
```
forge fmt --check   # clean
solhint             # 0 errors (only repo-standard naming/low-level warnings)
forge test --match-path "src/tornado/proposals/67/**"   # 7 passed, 0 failed
```
Verified locally forking at chain head via a non-censoring RPC (publicnode). The committed test pins block `25_427_000`, which (like the other proposal tests here) needs an **archive** `MAINNET_RPC_URL`. ⚠️ Several public RPCs (llamarpc, cloudflare) **block Tornado Cash calls** (OFAC) — a non-censoring endpoint is required.

## Notes / follow-up
- Self-contained (does not extend a DAO base). A full `Tornado_Governance` base + `dao-registry.json` entry (via the `dao-scaffold` pattern) is a sensible follow-up if Tornado becomes a first-class supported DAO here.
- Disclosure: L2Beat (S. Shemyakov) & pcaversaccio; decompilation via Dedaub (pcaversaccio gist).
