### PR TITLE
test(ens): EP 6.48 — Security Council renewal (Term 2)

### DIFF
--- a/src/ens/interfaces/ISecurityCouncil.sol
+++ b/src/ens/interfaces/ISecurityCouncil.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.25 <0.9.0;
+
+/// @notice Minimal interface for the ENS Security Council (Term 2) — blockful/security-council-ens.
+interface ISecurityCouncil {
+    function owner() external view returns (address);
+
+    function timelock() external view returns (address);
+
+    function expiration() external view returns (uint256);
+
+    function veto(bytes32 proposalId) external;
+
+    function extend(uint256 newExpiration) external;
+
+    function renounceTimelockRoleByExpiration() external;
+}

--- a/src/ens/proposals/ep-6-48/calldataCheck.t.sol
+++ b/src/ens/proposals/ep-6-48/calldataCheck.t.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.25 <0.9.0;
+
+import { ENS_Governance } from "@ens/ens.t.sol";
+import { ENSConstants } from "@ens/Constants.sol";
+import { ITimelock } from "@ens/interfaces/ITimelock.sol";
+import { ISecurityCouncil } from "@ens/interfaces/ISecurityCouncil.sol";
+
+/**
+ * @title Proposal_ENS_EP_6_48_Test
+ * @notice ENS EP 6.48 — Renewal of the Security Council (Term 2).
+ * @dev Grants PROPOSER_ROLE on the ENS timelock to the new SecurityCouncil contract. In this
+ *      timelock PROPOSER_ROLE gates cancel(), so the grant renews the council's veto power for
+ *      another two-year term. Single executable call.
+ */
+contract Proposal_ENS_EP_6_48_Test is ENS_Governance {
+    // Term 2 council — gets PROPOSER_ROLE from this proposal
+    ISecurityCouncil constant securityCouncil = ISecurityCouncil(0xDeDEdD439ecF711E61f5aeceF631579DBA2C65dB);
+    // Term 1 council — keeps its role until it self-expires on 2026-07-24
+    address constant oldSecurityCouncil = 0xB8fA0cE3f91F41C5292D07475b445c35ddF63eE0;
+    // 4-of-8 Safe that owns the council
+    address constant councilSafe = 0xaA5cD05f6B62C3af58AE9c4F3F7A2aCC2Cdc2Cc7;
+
+    uint256 constant expectedProposalId =
+        45_402_179_622_316_441_394_139_979_097_514_597_399_865_468_312_011_562_941_203_078_514_615_705_423_505;
+
+    function _selectFork() public override {
+        vm.createSelectFork({ blockNumber: 25_424_113, urlOrAlias: "mainnet" });
+    }
+
+    function _proposer() public pure override returns (address) {
+        return 0x809FA673fe2ab515FaA168259cB14E2BeDeBF68e; // avsa.eth
+    }
+
+    function _beforeProposal() public override {
+        assertEq(proposalId, expectedProposalId);
+
+        // Council is deployed and wired to the Safe and this timelock
+        assertEq(securityCouncil.owner(), councilSafe, "council not owned by the Safe");
+        assertEq(securityCouncil.timelock(), address(timelock), "council points to wrong timelock");
+        assertGt(securityCouncil.expiration(), block.timestamp, "council already expired");
+
+        // New council has no role yet; old one still holds it (this proposal does not revoke it)
+        assertFalse(timelock.hasRole(PROPOSER_ROLE, address(securityCouncil)), "new council already has role");
+        assertTrue(timelock.hasRole(PROPOSER_ROLE, oldSecurityCouncil), "old council lost its role");
+
+        // Without the role the veto reverts and the op stays pending
+        bytes32 pendingId = _scheduleDummyOperation("ep-6-48-before");
+        assertTrue(timelock.isOperationPending(pendingId));
+        vm.prank(councilSafe);
+        vm.expectRevert();
+        securityCouncil.veto(pendingId);
+        assertTrue(timelock.isOperationPending(pendingId));
+    }
+
+    function _generateCallData()
+        public
+        override
+        returns (address[] memory, uint256[] memory, string[] memory, bytes[] memory, string memory)
+    {
+        targets = new address[](1);
+        values = new uint256[](1);
+        calldatas = new bytes[](1);
+        signatures = new string[](1);
+
+        // Grant PROPOSER_ROLE (the timelock's cancel gate) to the new council
+        targets[0] = ENSConstants.TIMELOCK;
+        values[0] = 0;
+        calldatas[0] = abi.encodeWithSelector(ITimelock.grantRole.selector, PROPOSER_ROLE, address(securityCouncil));
+
+        description = getDescriptionFromMarkdown();
+
+        return (targets, values, signatures, calldatas, description);
+    }
+
+    function _afterExecution() public override {
+        // New council holds the role; old council's is unchanged
+        assertTrue(timelock.hasRole(PROPOSER_ROLE, address(securityCouncil)), "new council missing role");
+        assertTrue(timelock.hasRole(PROPOSER_ROLE, oldSecurityCouncil), "old council role changed");
+
+        // Council can now veto: the Safe cancels a pending timelock op
+        bytes32 pendingId = _scheduleDummyOperation("ep-6-48-after");
+        assertTrue(timelock.isOperationPending(pendingId));
+        vm.prank(councilSafe);
+        securityCouncil.veto(pendingId);
+        assertFalse(timelock.isOperation(pendingId), "op not cancelled");
+    }
+
+    // Schedule a no-op via the Governor (a proposer) to get a pending op to veto
+    function _scheduleDummyOperation(string memory saltSeed) internal returns (bytes32 id) {
+        address target = address(timelock);
+        uint256 value = 0;
+        bytes memory data = "";
+        bytes32 predecessor = bytes32(0);
+        bytes32 salt = keccak256(bytes(saltSeed));
+        uint256 delay = timelock.getMinDelay(); // read before prank, else it consumes the prank
+
+        vm.prank(ENSConstants.GOVERNOR);
+        timelock.schedule(target, value, data, predecessor, salt, delay);
+
+        id = timelock.hashOperation(target, value, data, predecessor, salt);
+    }
+
+    function _isProposalSubmitted() public pure override returns (bool) {
+        return true;
+    }
+
+    function dirPath() public pure override returns (string memory) {
+        return "src/ens/proposals/ep-6-48";
+    }
+}

--- a/src/ens/proposals/ep-6-48/proposalCalldata.json
+++ b/src/ens/proposals/ep-6-48/proposalCalldata.json
@@ -1,0 +1,14 @@
+{
+  "proposalId": "45402179622316441394139979097514597399865468312011562941203078514615705423505",
+  "blockNumber": 25424113,
+  "votingStart": 25424114,
+  "votingEnd": 25469932,
+  "createdAt": "2026-06-29T15:07:21.716295Z",
+  "executableCalls": [
+    {
+      "target": "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7",
+      "calldata": "0x2f2ff15db09aa5aeb3702cfd50b6b62bc4532604938f21248a27a1d5ca736082b6819cc1000000000000000000000000dededd439ecf711e61f5aecef631579dba2c65db",
+      "value": "0"
+    }
+  ]
+}

--- a/src/ens/proposals/ep-6-48/proposalDescription.md
+++ b/src/ens/proposals/ep-6-48/proposalDescription.md
@@ -1,0 +1,19 @@
+# [6.48][Executable] Renewal of the Security Council (Term 2)
+
+https://discuss.ens.domains/t/6-45-renewal-of-the-security-council/22145
+
+## Abstract
+
+The ENS DAO Security Council's veto authority expires on 24 July 2026, when renounceTimelockRoleByExpiration() becomes callable at Fri, Jul 24, 2026, 18:52:59 UTC. This proposal renews the council for a further two-year term. It deploys an updated SecurityCouncil contract that adds a extend() function callable only by the DAO timelock, so future renewals are a single governance vote rather than a fresh deployment and role re-grant. The new contract is audited before it is deployed, with the Meta-Governance Working Group funding the audit. The 4-of-8 multisig and the council's cancel-only emergency mandate are unchanged, with one signer rotation: lefteris.eth, who is no longer active in the DAO, is removed and coltron.eth, the largest active delegate not currently on the council, is added. This post has gone through the temperature check; and the Snapshot social vote, and now we are voting on the executable.
+
+## Specification
+
+### Background
+
+The Security Council is a 4-of-8 [Safe multisig](https://app.safe.global/home?safe=eth:0xaA5cD05f6B62C3af58AE9c4F3F7A2aCC2Cdc2Cc7) with a single power: to cancel malicious proposals in the ENS timelock. It cannot propose, amend, or initiate any governance action. It was approved through [EP 5.7 \[Social\]](https://snapshot.box/#/s:ens.eth/proposal/0xf3a4673fe04a3ecfed4a2f066f6ced1539a5466d61630428333360b843653c54), [EP 5.10 \[Social\]](https://snapshot.box/#/s:ens.eth/proposal/0xa0b1bfadf6853b5b0d59d3c4d73c434fc6389339887d05de805361372eb17c3a), and [EP 5.13 \[Executable\]](https://www.tally.xyz/gov/ens/proposal/42329103797433777309488042029679811802172320979541414683300183273376839219133) (passed 25 July 2024). The current contract is deployed at [0xb8fa0ce3f91f41c5292d07475b445c35ddf63ee0](https://etherscan.io/address/0xb8fa0ce3f91f41c5292d07475b445c35ddf63ee0) and its authority is time-limited: two years plus a 7-day buffer after deployment, anyone may call renounceTimelockRoleByExpiration() to permanently disable the cancel power, which occurs on 24 July 2026. The threat that motivated the council, a large treasury relative to active voting power, has not changed, so the recommendation is to renew rather than let it lapse.
+
+### New contract
+
+The current contract has no way to extend its own expiration, so renewing it requires deploying a new contract, passing an executable proposal to grant PROPOSER\_ROLE, and letting the old role expire. We propose deploying an updated SecurityCouncil contract ([blockful/security-council-ens](https://github.com/blockful/security-council-ens)) with the same cancel-only mandate and 4-of-8 ownership, plus an extend() function.
+
+The key safety property is that only the timelock can call extend(), so only a passed ENS DAO proposal can extend the term and the multisig cannot extend its own power. After this renewal, each subsequent renewal is a single extend() proposal with no redeploy and no re-grant.


### PR DESCRIPTION
## EP 6.48 — Renewal of the Security Council (Term 2)

Live calldata review. Single executable call: `grantRole(PROPOSER_ROLE, 0xDeDEdD…65dB)` on the ENS timelock, renewing the council's cancel-only veto for another two-year term.

### Verification
- Derived calldata matches `proposalCalldata.json` byte-for-byte; recomputed `proposalId` equals the on-chain id.
- New council contract verified: owner = 4-of-8 Safe, `timelock()` = ENS timelock, `expiration` in the future, no schedule/execute surface (cancel-only).
- Assertions prove veto reverts before the grant and cancels a real pending op after.

```
forge test --match-path "src/ens/proposals/ep-6-48/*" -vv
[PASS] test_proposal()
```

**Recommendation: APPROVE**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds proposal verification tests, a minimal interface, and metadata; no production governance or timelock logic changes in this repo.
> 
> **Overview**
> Adds **ENS EP 6.48** live calldata review for renewing the Security Council (Term 2): a single timelock `grantRole(PROPOSER_ROLE, …)` to the new council at `0xDeDEdD…65dB`.
> 
> Introduces `ISecurityCouncil` for veto/extend wiring checks, plus `proposalCalldata.json`, `proposalDescription.md`, and a forked `ENS_Governance` test that asserts derived calldata and `proposalId` match on-chain, Term 2 is Safe-owned and not yet a proposer while Term 1 still is, **veto fails before execution**, and **veto cancels a pending op after**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18a49931e049641368be76af3f5c99b8a6ad649b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->