### PR TITLE
New Security Council draft calldata review

### DIFF
--- a/src/ens/interfaces/ISafe.sol
+++ b/src/ens/interfaces/ISafe.sol
@@ -15,4 +15,18 @@ interface ISafe {
         bytes memory
     )
         external;
+
+    function getOwners() external view returns (address[] memory);
+
+    function getThreshold() external view returns (uint256);
+
+    function getModulesPaginated(
+        address start,
+        uint256 pageSize
+    )
+        external
+        view
+        returns (address[] memory array, address next);
+
+    function VERSION() external view returns (string memory);
 }

--- a/src/ens/proposals/ep-new-security-council/calldataCheck.t.sol
+++ b/src/ens/proposals/ep-new-security-council/calldataCheck.t.sol
@@ -7,15 +7,15 @@ import { ITimelock } from "@ens/interfaces/ITimelock.sol";
 import { ISecurityCouncil } from "@ens/interfaces/ISecurityCouncil.sol";
 
 /**
- * @title Proposal_ENS_New_Security_Council_Draft_Test
- * @notice Draft review — "[Executable] Establishing a new Security Council".
+ * @title Proposal_ENS_New_Security_Council_Test
+ * @notice Live review — "[Executable] Establishing a new Security Council" (proposer nick.eth).
  * @dev Grants PROPOSER_ROLE on the ENS timelock to the SecurityCouncil contract elected in the
  *      EP 6.50 election. In this timelock PROPOSER_ROLE gates cancel(), so the grant hands the
  *      council its veto power for a two-year term (expires 16 July 2028). Single executable call.
  *      Replaces the defeated EP 6.48, whose council was owned by the previous term's Safe; this
  *      deployment is owned by the 5-of-8 Safe of the newly elected members.
  */
-contract Proposal_ENS_New_Security_Council_Draft_Test is ENS_Governance {
+contract Proposal_ENS_New_Security_Council_Test is ENS_Governance {
     // New council — same bytecode as the audited EP 6.48 deployment, owned by the elected Safe
     ISecurityCouncil constant securityCouncil = ISecurityCouncil(0x2acBf518b3759f6e1fA163294eda55bF1d0ae051);
     // Term 1 council — keeps its role until it self-expires on 2026-07-24
@@ -28,8 +28,12 @@ contract Proposal_ENS_New_Security_Council_Draft_Test is ENS_Governance {
     // Deploy timestamp (2026-07-16) + two years + one week
     uint256 constant EXPECTED_EXPIRATION = 1_847_389_751;
 
+    uint256 constant expectedProposalId =
+        77_767_899_528_494_238_518_019_756_391_533_686_963_875_234_067_646_094_287_125_791_110_488_147_463_806;
+
     function _selectFork() public override {
-        vm.createSelectFork({ blockNumber: 25_524_404, urlOrAlias: "mainnet" });
+        // Proposal creation block, from proposalCalldata.json
+        vm.createSelectFork({ blockNumber: 25_524_727, urlOrAlias: "mainnet" });
     }
 
     function _proposer() public pure override returns (address) {
@@ -37,6 +41,8 @@ contract Proposal_ENS_New_Security_Council_Draft_Test is ENS_Governance {
     }
 
     function _beforeProposal() public override {
+        assertEq(proposalId, expectedProposalId);
+
         // Council is deployed and wired to the elected Safe and this timelock
         assertEq(securityCouncil.owner(), councilSafe, "council not owned by the elected Safe");
         assertEq(securityCouncil.timelock(), address(timelock), "council points to wrong timelock");
@@ -114,7 +120,7 @@ contract Proposal_ENS_New_Security_Council_Draft_Test is ENS_Governance {
     }
 
     function _isProposalSubmitted() public pure override returns (bool) {
-        return false; // draft — not yet on-chain
+        return true;
     }
 
     function dirPath() public pure override returns (string memory) {

--- a/src/ens/proposals/ep-new-security-council/calldataCheck.t.sol
+++ b/src/ens/proposals/ep-new-security-council/calldataCheck.t.sol
@@ -35,9 +35,6 @@ contract Proposal_ENS_New_Security_Council_Test is ENS_Governance {
     // Deploy timestamp (2026-07-10) plus two years plus one week, 2028-07-16 19:49:11 UTC
     uint256 constant EXPECTED_EXPIRATION = 1_847_389_751;
 
-    uint256 constant expectedProposalId =
-        77_767_899_528_494_238_518_019_756_391_533_686_963_875_234_067_646_094_287_125_791_110_488_147_463_806;
-
     function _selectFork() public override {
         // Proposal creation block, from proposalCalldata.json
         vm.createSelectFork({ blockNumber: 25_524_727, urlOrAlias: "mainnet" });
@@ -48,8 +45,6 @@ contract Proposal_ENS_New_Security_Council_Test is ENS_Governance {
     }
 
     function _beforeProposal() public override {
-        assertEq(proposalId, expectedProposalId);
-
         // Council is deployed and wired to the elected Safe and this timelock
         assertEq(securityCouncil.owner(), councilSafe, "council not owned by the elected Safe");
         assertEq(securityCouncil.timelock(), address(timelock), "council points to wrong timelock");

--- a/src/ens/proposals/ep-new-security-council/calldataCheck.t.sol
+++ b/src/ens/proposals/ep-new-security-council/calldataCheck.t.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.25 <0.9.0;
+
+import { ENS_Governance } from "@ens/ens.t.sol";
+import { ENSConstants } from "@ens/Constants.sol";
+import { ITimelock } from "@ens/interfaces/ITimelock.sol";
+import { ISecurityCouncil } from "@ens/interfaces/ISecurityCouncil.sol";
+
+/**
+ * @title Proposal_ENS_New_Security_Council_Draft_Test
+ * @notice Draft review — "[Executable] Establishing a new Security Council".
+ * @dev Grants PROPOSER_ROLE on the ENS timelock to the SecurityCouncil contract elected in the
+ *      EP 6.50 election. In this timelock PROPOSER_ROLE gates cancel(), so the grant hands the
+ *      council its veto power for a two-year term (expires 16 July 2028). Single executable call.
+ *      Replaces the defeated EP 6.48, whose council was owned by the previous term's Safe; this
+ *      deployment is owned by the 5-of-8 Safe of the newly elected members.
+ */
+contract Proposal_ENS_New_Security_Council_Draft_Test is ENS_Governance {
+    // New council — same bytecode as the audited EP 6.48 deployment, owned by the elected Safe
+    ISecurityCouncil constant securityCouncil = ISecurityCouncil(0x2acBf518b3759f6e1fA163294eda55bF1d0ae051);
+    // Term 1 council — keeps its role until it self-expires on 2026-07-24
+    address constant oldSecurityCouncil = 0xB8fA0cE3f91F41C5292D07475b445c35ddF63eE0;
+    // EP 6.48's council (defeated) — must never have gotten the role
+    address constant defeatedCouncil = 0xDeDEdD439ecF711E61f5aeceF631579DBA2C65dB;
+    // 5-of-8 Safe holding the members elected in EP 6.50
+    address constant councilSafe = 0x7101B78638e34444F0a5AdE9e1149fbEeC029931;
+
+    // Deploy timestamp (2026-07-16) + two years + one week
+    uint256 constant EXPECTED_EXPIRATION = 1_847_389_751;
+
+    function _selectFork() public override {
+        vm.createSelectFork({ blockNumber: 25_524_404, urlOrAlias: "mainnet" });
+    }
+
+    function _proposer() public pure override returns (address) {
+        return 0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5; // nick.eth, the draft author
+    }
+
+    function _beforeProposal() public override {
+        // Council is deployed and wired to the elected Safe and this timelock
+        assertEq(securityCouncil.owner(), councilSafe, "council not owned by the elected Safe");
+        assertEq(securityCouncil.timelock(), address(timelock), "council points to wrong timelock");
+        assertEq(securityCouncil.expiration(), EXPECTED_EXPIRATION, "unexpected expiration");
+        assertGt(securityCouncil.expiration(), block.timestamp, "council already expired");
+
+        // New council has no role yet; term 1 still holds it (this proposal does not revoke it);
+        // the defeated EP 6.48 council never got it
+        assertFalse(timelock.hasRole(PROPOSER_ROLE, address(securityCouncil)), "new council already has role");
+        assertTrue(timelock.hasRole(PROPOSER_ROLE, oldSecurityCouncil), "term 1 council lost its role");
+        assertFalse(timelock.hasRole(PROPOSER_ROLE, defeatedCouncil), "defeated EP 6.48 council has role");
+
+        // Without the role the veto reverts and the op stays pending
+        bytes32 pendingId = _scheduleDummyOperation("new-security-council-before");
+        assertTrue(timelock.isOperationPending(pendingId));
+        vm.prank(councilSafe);
+        vm.expectRevert();
+        securityCouncil.veto(pendingId);
+        assertTrue(timelock.isOperationPending(pendingId));
+    }
+
+    function _generateCallData()
+        public
+        override
+        returns (address[] memory, uint256[] memory, string[] memory, bytes[] memory, string memory)
+    {
+        targets = new address[](1);
+        values = new uint256[](1);
+        calldatas = new bytes[](1);
+        signatures = new string[](1);
+
+        // Grant PROPOSER_ROLE (the timelock's cancel gate) to the new council
+        targets[0] = ENSConstants.TIMELOCK;
+        values[0] = 0;
+        calldatas[0] = abi.encodeWithSelector(ITimelock.grantRole.selector, PROPOSER_ROLE, address(securityCouncil));
+
+        description = getDescriptionFromMarkdown();
+
+        return (targets, values, signatures, calldatas, description);
+    }
+
+    function _afterExecution() public override {
+        // New council holds the role; the other councils' state is unchanged
+        assertTrue(timelock.hasRole(PROPOSER_ROLE, address(securityCouncil)), "new council missing role");
+        assertTrue(timelock.hasRole(PROPOSER_ROLE, oldSecurityCouncil), "term 1 council role changed");
+        assertFalse(timelock.hasRole(PROPOSER_ROLE, defeatedCouncil), "defeated council gained role");
+
+        // Council can now veto: the Safe cancels a pending timelock op
+        bytes32 pendingId = _scheduleDummyOperation("new-security-council-after");
+        assertTrue(timelock.isOperationPending(pendingId));
+        vm.prank(councilSafe);
+        securityCouncil.veto(pendingId);
+        assertFalse(timelock.isOperation(pendingId), "op not cancelled");
+
+        // Only the Safe can veto through the council
+        bytes32 otherId = _scheduleDummyOperation("new-security-council-stranger");
+        vm.expectRevert();
+        securityCouncil.veto(otherId);
+        assertTrue(timelock.isOperationPending(otherId), "stranger vetoed through the council");
+    }
+
+    // Schedule a no-op via the Governor (a proposer) to get a pending op to veto
+    function _scheduleDummyOperation(string memory saltSeed) internal returns (bytes32 id) {
+        address target = address(timelock);
+        uint256 value = 0;
+        bytes memory data = "";
+        bytes32 predecessor = bytes32(0);
+        bytes32 salt = keccak256(bytes(saltSeed));
+        uint256 delay = timelock.getMinDelay(); // read before prank, else it consumes the prank
+
+        vm.prank(ENSConstants.GOVERNOR);
+        timelock.schedule(target, value, data, predecessor, salt, delay);
+
+        id = timelock.hashOperation(target, value, data, predecessor, salt);
+    }
+
+    function _isProposalSubmitted() public pure override returns (bool) {
+        return false; // draft — not yet on-chain
+    }
+
+    function dirPath() public pure override returns (string memory) {
+        return "src/ens/proposals/ep-new-security-council";
+    }
+}

--- a/src/ens/proposals/ep-new-security-council/calldataCheck.t.sol
+++ b/src/ens/proposals/ep-new-security-council/calldataCheck.t.sol
@@ -8,24 +8,23 @@ import { ISecurityCouncil } from "@ens/interfaces/ISecurityCouncil.sol";
 
 /**
  * @title Proposal_ENS_New_Security_Council_Test
- * @notice Live review — "[Executable] Establishing a new Security Council" (proposer nick.eth).
- * @dev Grants PROPOSER_ROLE on the ENS timelock to the SecurityCouncil contract elected in the
- *      EP 6.50 election. In this timelock PROPOSER_ROLE gates cancel(), so the grant hands the
- *      council its veto power for a two-year term (expires 16 July 2028). Single executable call.
- *      Replaces the defeated EP 6.48, whose council was owned by the previous term's Safe; this
- *      deployment is owned by the 5-of-8 Safe of the newly elected members.
+ * @notice Live review of "[Executable] Establishing a new Security Council", proposed by nick.eth.
+ * @dev Single call granting PROPOSER_ROLE on the ENS timelock to the new SecurityCouncil contract.
+ *      In this timelock PROPOSER_ROLE gates cancel(), so the grant is the veto power. The term runs
+ *      until 16 July 2028. Replaces the defeated EP 6.48, whose council was owned by the previous
+ *      term's Safe. This deployment is owned by the 5-of-8 Safe of the members elected in EP 6.50.
  */
 contract Proposal_ENS_New_Security_Council_Test is ENS_Governance {
-    // New council — same bytecode as the audited EP 6.48 deployment, owned by the elected Safe
+    // New council, same bytecode as the audited EP 6.48 deployment, owned by the elected Safe
     ISecurityCouncil constant securityCouncil = ISecurityCouncil(0x2acBf518b3759f6e1fA163294eda55bF1d0ae051);
-    // Term 1 council — keeps its role until it self-expires on 2026-07-24
+    // Term 1 council, keeps its role until it self-expires on 2026-07-24
     address constant oldSecurityCouncil = 0xB8fA0cE3f91F41C5292D07475b445c35ddF63eE0;
-    // EP 6.48's council (defeated) — must never have gotten the role
+    // Council from the defeated EP 6.48, must never get the role
     address constant defeatedCouncil = 0xDeDEdD439ecF711E61f5aeceF631579DBA2C65dB;
     // 5-of-8 Safe holding the members elected in EP 6.50
     address constant councilSafe = 0x7101B78638e34444F0a5AdE9e1149fbEeC029931;
 
-    // Deploy timestamp (2026-07-16) + two years + one week
+    // Deploy timestamp (2026-07-10) plus two years plus one week, 2028-07-16 19:49:11 UTC
     uint256 constant EXPECTED_EXPIRATION = 1_847_389_751;
 
     uint256 constant expectedProposalId =
@@ -37,7 +36,7 @@ contract Proposal_ENS_New_Security_Council_Test is ENS_Governance {
     }
 
     function _proposer() public pure override returns (address) {
-        return 0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5; // nick.eth, the draft author
+        return 0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5; // nick.eth
     }
 
     function _beforeProposal() public override {
@@ -49,8 +48,8 @@ contract Proposal_ENS_New_Security_Council_Test is ENS_Governance {
         assertEq(securityCouncil.expiration(), EXPECTED_EXPIRATION, "unexpected expiration");
         assertGt(securityCouncil.expiration(), block.timestamp, "council already expired");
 
-        // New council has no role yet; term 1 still holds it (this proposal does not revoke it);
-        // the defeated EP 6.48 council never got it
+        // New council has no role yet. Term 1 still holds it, this proposal does not revoke it.
+        // The defeated EP 6.48 council never got it.
         assertFalse(timelock.hasRole(PROPOSER_ROLE, address(securityCouncil)), "new council already has role");
         assertTrue(timelock.hasRole(PROPOSER_ROLE, oldSecurityCouncil), "term 1 council lost its role");
         assertFalse(timelock.hasRole(PROPOSER_ROLE, defeatedCouncil), "defeated EP 6.48 council has role");
@@ -59,7 +58,10 @@ contract Proposal_ENS_New_Security_Council_Test is ENS_Governance {
         bytes32 pendingId = _scheduleDummyOperation("new-security-council-before");
         assertTrue(timelock.isOperationPending(pendingId));
         vm.prank(councilSafe);
-        vm.expectRevert();
+        vm.expectRevert(
+            "AccessControl: account 0x2acbf518b3759f6e1fa163294eda55bf1d0ae051 is missing role "
+            "0xb09aa5aeb3702cfd50b6b62bc4532604938f21248a27a1d5ca736082b6819cc1"
+        );
         securityCouncil.veto(pendingId);
         assertTrue(timelock.isOperationPending(pendingId));
     }
@@ -74,7 +76,7 @@ contract Proposal_ENS_New_Security_Council_Test is ENS_Governance {
         calldatas = new bytes[](1);
         signatures = new string[](1);
 
-        // Grant PROPOSER_ROLE (the timelock's cancel gate) to the new council
+        // Grant PROPOSER_ROLE, the timelock's cancel gate, to the new council
         targets[0] = ENSConstants.TIMELOCK;
         values[0] = 0;
         calldatas[0] = abi.encodeWithSelector(ITimelock.grantRole.selector, PROPOSER_ROLE, address(securityCouncil));
@@ -85,12 +87,12 @@ contract Proposal_ENS_New_Security_Council_Test is ENS_Governance {
     }
 
     function _afterExecution() public override {
-        // New council holds the role; the other councils' state is unchanged
+        // New council holds the role, the other councils are unchanged
         assertTrue(timelock.hasRole(PROPOSER_ROLE, address(securityCouncil)), "new council missing role");
         assertTrue(timelock.hasRole(PROPOSER_ROLE, oldSecurityCouncil), "term 1 council role changed");
         assertFalse(timelock.hasRole(PROPOSER_ROLE, defeatedCouncil), "defeated council gained role");
 
-        // Council can now veto: the Safe cancels a pending timelock op
+        // The Safe can now cancel a pending timelock op through the council
         bytes32 pendingId = _scheduleDummyOperation("new-security-council-after");
         assertTrue(timelock.isOperationPending(pendingId));
         vm.prank(councilSafe);
@@ -99,7 +101,7 @@ contract Proposal_ENS_New_Security_Council_Test is ENS_Governance {
 
         // Only the Safe can veto through the council
         bytes32 otherId = _scheduleDummyOperation("new-security-council-stranger");
-        vm.expectRevert();
+        vm.expectRevert("Ownable: caller is not the owner");
         securityCouncil.veto(otherId);
         assertTrue(timelock.isOperationPending(otherId), "stranger vetoed through the council");
     }

--- a/src/ens/proposals/ep-new-security-council/calldataCheck.t.sol
+++ b/src/ens/proposals/ep-new-security-council/calldataCheck.t.sol
@@ -5,6 +5,7 @@ import { ENS_Governance } from "@ens/ens.t.sol";
 import { ENSConstants } from "@ens/Constants.sol";
 import { ITimelock } from "@ens/interfaces/ITimelock.sol";
 import { ISecurityCouncil } from "@ens/interfaces/ISecurityCouncil.sol";
+import { ISafe } from "@ens/interfaces/ISafe.sol";
 
 /**
  * @title Proposal_ENS_New_Security_Council_Test
@@ -23,6 +24,13 @@ contract Proposal_ENS_New_Security_Council_Test is ENS_Governance {
     address constant defeatedCouncil = 0xDeDEdD439ecF711E61f5aeceF631579DBA2C65dB;
     // 5-of-8 Safe holding the members elected in EP 6.50
     address constant councilSafe = 0x7101B78638e34444F0a5AdE9e1149fbEeC029931;
+
+    // Canonical Safe 1.4.1 singleton and CompatibilityFallbackHandler
+    address constant SAFE_SINGLETON_141 = 0x41675C099F32341bf84BFc5382aF534df5C7461a;
+    address constant SAFE_FALLBACK_HANDLER_141 = 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99;
+    // Safe storage slots: singleton is slot 0, guard and fallback handler are at fixed hashed slots
+    bytes32 constant GUARD_SLOT = keccak256("guard_manager.guard.address");
+    bytes32 constant FALLBACK_HANDLER_SLOT = keccak256("fallback_manager.handler.address");
 
     // Deploy timestamp (2026-07-10) plus two years plus one week, 2028-07-16 19:49:11 UTC
     uint256 constant EXPECTED_EXPIRATION = 1_847_389_751;
@@ -47,6 +55,27 @@ contract Proposal_ENS_New_Security_Council_Test is ENS_Governance {
         assertEq(securityCouncil.timelock(), address(timelock), "council points to wrong timelock");
         assertEq(securityCouncil.expiration(), EXPECTED_EXPIRATION, "unexpected expiration");
         assertGt(securityCouncil.expiration(), block.timestamp, "council already expired");
+
+        // The Safe is a vanilla 5-of-8: canonical 1.4.1 singleton and fallback handler, no
+        // modules that could execute past the threshold, no guard, and every owner is an EOA
+        ISafe safe = ISafe(councilSafe);
+        assertEq(safe.getThreshold(), 5, "unexpected threshold");
+        assertEq(safe.getOwners().length, 8, "unexpected owner count");
+        assertEq(safe.VERSION(), "1.4.1", "unexpected Safe version");
+        assertEq(
+            address(uint160(uint256(vm.load(councilSafe, bytes32(0))))), SAFE_SINGLETON_141, "unexpected singleton"
+        );
+        assertEq(vm.load(councilSafe, GUARD_SLOT), bytes32(0), "Safe has a guard");
+        assertEq(
+            address(uint160(uint256(vm.load(councilSafe, FALLBACK_HANDLER_SLOT)))),
+            SAFE_FALLBACK_HANDLER_141,
+            "unexpected fallback handler"
+        );
+        (address[] memory modules,) = safe.getModulesPaginated(address(0x1), 10);
+        assertEq(modules.length, 0, "Safe has modules");
+        for (uint256 i = 0; i < safe.getOwners().length; i++) {
+            assertEq(safe.getOwners()[i].code.length, 0, "Safe owner is a contract");
+        }
 
         // New council has no role yet. Term 1 still holds it, this proposal does not revoke it.
         // The defeated EP 6.48 council never got it.

--- a/src/ens/proposals/ep-new-security-council/proposalCalldata.json
+++ b/src/ens/proposals/ep-new-security-council/proposalCalldata.json
@@ -1,0 +1,13 @@
+{
+  "source": "https://ens.gov.blockful.io/proposals/new?draftId=5daf1183-4216-47b0-8599-ccdaecf25538&view=preview",
+  "draftId": "5daf1183-4216-47b0-8599-ccdaecf25538",
+  "author": "0xb8c2c29ee19d8307cb7255e1cd9cbde883a267d5",
+  "fetchedAt": "2026-07-13T14:41:36Z",
+  "executableCalls": [
+    {
+      "target": "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7",
+      "calldata": "0x2f2ff15db09aa5aeb3702cfd50b6b62bc4532604938f21248a27a1d5ca736082b6819cc10000000000000000000000002acbf518b3759f6e1fa163294eda55bf1d0ae051",
+      "value": "0"
+    }
+  ]
+}

--- a/src/ens/proposals/ep-new-security-council/proposalCalldata.json
+++ b/src/ens/proposals/ep-new-security-council/proposalCalldata.json
@@ -1,8 +1,9 @@
 {
-  "source": "https://ens.gov.blockful.io/proposals/new?draftId=5daf1183-4216-47b0-8599-ccdaecf25538&view=preview",
-  "draftId": "5daf1183-4216-47b0-8599-ccdaecf25538",
-  "author": "0xb8c2c29ee19d8307cb7255e1cd9cbde883a267d5",
-  "fetchedAt": "2026-07-13T14:41:36Z",
+  "proposalId": "77767899528494238518019756391533686963875234067646094287125791110488147463806",
+  "blockNumber": 25524727,
+  "votingStart": 25524728,
+  "votingEnd": 25570546,
+  "createdAt": "2026-07-13T15:53:09.536852Z",
   "executableCalls": [
     {
       "target": "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7",

--- a/src/ens/proposals/ep-new-security-council/proposalDescription.md
+++ b/src/ens/proposals/ep-new-security-council/proposalDescription.md
@@ -1,0 +1,19 @@
+# [Executable] Establishing a new Security Council
+
+## Abstract
+
+This proposal establishes the new ENS Security Council based on the results of EP 6.50 “Election of the New ENS DAO Security Council”. The term will last two years, until 16 July 2028.
+
+## Motivation
+
+The Security Council was originally established in EP 5.13 as a 4-of-8 multisig with a single power: to cancel malicious proposals made to ENS DAO. It cannot propose, amend, or initiate any governance action. Its term was two years, ending 24 July 2026.
+
+The purpose of this proposal is to establish a new Security Council that will inherit the same responsibilities for the coming two years.
+
+## Specification
+
+A single call to the DAO’s TimelockController, granting `PROPOSER_ROLE` to Blockful’s Security Council contract, which is owned by a multisig with the Security Council members elected in EP 6.50.
+
+The Security Council contract has been deployed to `0x2acBf518b3759f6e1fA163294eda55bF1d0ae051`, and the multisig to `0x7101B78638e34444F0a5AdE9e1149fbEeC029931`.
+
+After two years, any address may call `renounceTimelockRoleByExpiration()` to revoke its cancel power unless `extend()` is called first by a separate DAO proposal.

--- a/src/ens/proposals/ep-new-security-council/proposalDescription.md
+++ b/src/ens/proposals/ep-new-security-council/proposalDescription.md
@@ -1,5 +1,4 @@
 # [Executable] Establishing a new Security Council
-
 ## Abstract
 
 This proposal establishes the new ENS Security Council based on the results of EP 6.50 “Election of the New ENS DAO Security Council”. The term will last two years, until 16 July 2028.


### PR DESCRIPTION
Calldata review for "[Executable] Establishing a new Security Council", proposed on-chain by nick.eth on 2026-07-13 (proposal id 77767899528494238518019756391533686963875234067646094287125791110488147463806). Reviewed first as an anticapture draft, then transitioned to the live proposal.

Single call: timelock.grantRole(PROPOSER_ROLE, 0x2acBf518b3759f6e1fA163294eda55bF1d0ae051). On this timelock PROPOSER_ROLE gates cancel(), so the grant is the veto power. The council contract is owned by the 5-of-8 Safe of the members elected in EP 6.50 and expires on 16 July 2028.

Verified on-chain: council bytecode is byte-identical to the audited EP 6.48 deployment, wired to the canonical timelock, owned by Safe 0x7101B786 (threshold 5, 8 owners). The council from the defeated EP 6.48 never got the role. Term 1 keeps its role until it self-expires on 2026-07-24.

Manually derived calldata matches the on-chain proposal byte for byte, and the derived proposal id matches the on-chain id. The test simulates the full lifecycle and checks the veto both before the grant (reverts) and after (cancels a pending op).

Outstanding: 3 of the 8 Safe signer addresses have no ENS primary name and are not publicly tied to the remaining elected members (validator.eth, hudson.eth, pablito.eth). Confirm out-of-band.