### PR TITLE
ci: add ClickUp sync workflow

### DIFF
--- a/.github/workflows/clickup.yaml
+++ b/.github/workflows/clickup.yaml
@@ -1,0 +1,26 @@
+name: ClickUp sync
+
+on:
+  create:
+  pull_request:
+    types: [opened, ready_for_review, synchronize, closed]
+  pull_request_review:
+    types: [submitted]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pr-sync:
+    if: github.event_name != 'push'
+    uses: blockful/.github/.github/workflows/clickup-pr-sync.yaml@main
+    secrets:
+      clickup_token: ${{ secrets.CLICKUP_API_TOKEN }}
+  release-sync:
+    if: github.event_name == 'push'
+    uses: blockful/.github/.github/workflows/clickup-release-sync.yaml@main
+    secrets:
+      clickup_token: ${{ secrets.CLICKUP_API_TOKEN }}


### PR DESCRIPTION
Adds the same ClickUp sync workflow already running in [blockful/anticapture](https://github.com/blockful/anticapture/blob/main/.github/workflows/clickup.yaml).

It delegates to the reusable workflows in `blockful/.github`:
- **pr-sync** (`clickup-pr-sync.yaml`): syncs ClickUp task status on branch creation, PR opened/ready/synchronize/closed and PR reviews
- **release-sync** (`clickup-release-sync.yaml`): syncs on push to `main`

Requires the `CLICKUP_API_TOKEN` secret to be available to this repo (org-level secret or repo secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)